### PR TITLE
Update staticcheck to v0.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: go mod download
     - name: Lint
       run: |
-        go install honnef.co/go/tools/cmd/staticcheck@v0.2.1
+        go install honnef.co/go/tools/cmd/staticcheck@v0.2.2
         $(go env GOPATH)/bin/staticcheck ./...
     - name: Test
       run: make test


### PR DESCRIPTION
Fixes broken builds on master right now.